### PR TITLE
Restrict pip install to 3.15.0 prior to v4 release to allow for v4 va…

### DIFF
--- a/Prowler-Resources.yaml
+++ b/Prowler-Resources.yaml
@@ -463,7 +463,7 @@ Resources:
             cd /usr/local/prowler
 
             #Install Prowler via pip3
-            pip install prowler
+            pip install prowler==3.15.0
 
             #Install Python Report Dependencies
             pip install matplotlib numpy


### PR DESCRIPTION
v4 Prowler to be released on 4-4-24.  May have breaking changes.
Restricting installed prowler version to 3.15.0.
Once v4 is released and validated, will remove restriction.