### PR TITLE
Enable easy way to have Prowler run on deployed-to account

### DIFF
--- a/prowler_scan.sh
+++ b/prowler_scan.sh
@@ -15,6 +15,7 @@
 #       Utilize appropriately sized EC2 instance (8=r6i.large,12=r6i.xlarge, 16=r6i.2xlarge)
 #   2) AWSACCOUNT_LIST: Specify the accounts to be assessed using one of the supported methods:
 #       Use the keyword allaccounts to generate a list of all accounts in the AWS Org
+#       Use the keyword thisaccount to specify only the account where this script is deployed
 #       Use the keyword inputfile to read in AWS Account IDs from a file (If using this mode, must also set AWSACCOUNT_LIST_FILE)
 #       Use a space separated list of AWS Account IDs
 #   3) AWSACCOUNT_LIST_FILE: If using AWSACCOUNT_LIST="inputfile", specify the path to the file

--- a/prowler_scan.sh
+++ b/prowler_scan.sh
@@ -48,6 +48,7 @@ PARALLELISM="12"
 #Specify accounts to be assessed using one of the supported methods:
 AWSACCOUNT_LIST="allaccounts"
 #AWSACCOUNT_LIST="inputfile"
+#AWSACCOUNT_LIST="thisaccount"
 #AWSACCOUNT_LIST="123456789012 210987654321"
 
 #If using AWSACCOUNT_LIST="inputfile", specify the path to the file:
@@ -132,6 +133,8 @@ elif [ "$AWSACCOUNT_LIST" = "inputfile" ]; then
         echo "External file $AWSACCOUNT_LIST_FILE not located. Please validate the file/path and update the AWSACCOUNT_LIST_FILE variable."
         exit 0
     fi
+elif [ "$AWSACCOUNT_LIST" = "thisaccount" ]; then
+    ACCOUNTS_TO_PROCESS=$(aws sts get-caller-identity  --query Account --output text)
 else
     ACCOUNTS_TO_PROCESS=$AWSACCOUNT_LIST
 fi


### PR DESCRIPTION
*Issue #, if available:* None

*Description of changes:*

Updates to `prowler_scan.sh` to allow `thisaccount` as a keyword input for `AWSACCOUNT_LIST` configuration parameter.  When set to this value, the `AWSACCOUNT_LIST` is set to the Account ID of the account in which the tool has been deployed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
